### PR TITLE
changed default gam/bam options to drop the intercept term;

### DIFF
--- a/R/CTest.R
+++ b/R/CTest.R
@@ -70,7 +70,8 @@ CTest = function(differentialtimevaryingpredictors = differentialtimevaryingpred
                         data = laglongreducedummy,
                         na.action = na.omit,
                         gamma = gamma,
-                        weights = weights),
+                        weights = weights,
+                        drop.intercept = TRUE),
                   silent = TRUE)
     if (try(summary(trytest)[2], silent = TRUE)
         == "try-error") {
@@ -83,9 +84,10 @@ CTest = function(differentialtimevaryingpredictors = differentialtimevaryingpred
                       data = laglongreducedummy,
                       na.action = na.omit,
                       gamma = gamma,
-                      discrete = TRUE,
+                      discrete = FALSE,
                       method = "fREML",
-                      weights = weights
+                      weights = weights,
+                      drop.intercept = TRUE,
                     ),
                   silent = TRUE)
     if (try(summary(trytest)[2], silent = TRUE)


### PR DESCRIPTION
drop.intercept term is now TRUE, with discrete = FALSE in bam. This eliminates small absolute value bias found during simulation study